### PR TITLE
667: Fix missing coder for Rails 7.1

### DIFF
--- a/lib/rpush/client/active_record/notification.rb
+++ b/lib/rpush/client/active_record/notification.rb
@@ -7,8 +7,8 @@ module Rpush
 
         self.table_name = 'rpush_notifications'
 
-        serialize :registration_ids
-        serialize :url_args
+        serialize :registration_ids, coder: YAML
+        serialize :url_args, coder: YAML
 
         belongs_to :app, class_name: 'Rpush::Client::ActiveRecord::App'
 


### PR DESCRIPTION
add `coder: YAML` for `registration_ids` and `url_args`